### PR TITLE
Support inlining templates

### DIFF
--- a/domthingify.js
+++ b/domthingify.js
@@ -1,33 +1,64 @@
 var through = require('through');
 var domthing = require('domthing');
+var staticModule = require('static-module');
+var Readable = require('stream').Readable;
 
 module.exports = function (fileName) {
-    if (!/\.dom$/i.test(fileName)) {
-        return through();
+
+    if (/\.dom$/i.test(fileName)) {
+        var inputString = '';
+
+        return through(
+            function (chunk) {
+                inputString += chunk;
+            },
+            function () {
+                domthing.parser(inputString, function (err, ast) {
+                    if (err) return this.emit('error', err);
+
+                    var compiled = domthing.compiler.compile(ast);
+
+                    var moduleBody = [
+                        "var _runtime = require('domthing/runtime');",
+                        "module.exports = function (template, runtime) {",
+                        "    return " + compiled + "(template, runtime || _runtime);",
+                        "}"
+                    ].join('\n');
+
+                    this.queue(moduleBody);
+                    this.queue(null);
+                }.bind(this));
+            }
+        );
     }
 
-    var inputString = '';
+    var sm = staticModule({
+        domthingify: function (str) {
+            var stream = new Readable();
 
-    return through(
-        function (chunk) {
-            inputString += chunk;
-        },
-        function () {
-            domthing.parser(inputString, function (err, ast) {
-                if (err) return this.emit('error', err);
+            domthing.parser(str, function (err, ast) {
+                if (err) return stream.emit('error', err);
 
                 var compiled = domthing.compiler.compile(ast);
 
                 var moduleBody = [
-                    "var _runtime = require('domthing/runtime');",
-                    "module.exports = function (template, runtime) {",
-                    "    return " + compiled + "(template, runtime || _runtime);",
-                    "}"
+                    "(function () {",
+                    "    var _runtime = require('domthing/runtime');",
+                    "    return function (template, runtime) {",
+                    "        return " + compiled + "(template, runtime || _runtime);",
+                    "    }",
+                    "}())"
                 ].join('\n');
 
-                this.queue(moduleBody);
-                this.queue(null);
+                stream.push(moduleBody);
+                stream.push(null);
+
             }.bind(this));
+
+            return stream;
         }
-    );
+    });
+
+    return sm;
+
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "domthing": "^0.1.0",
-    "through": "^2.3.4"
+    "through": "^2.3.4",
+    "static-module": "~1.0.0"
   },
   "devDependencies": {
     "beefy": "^2.0.1"


### PR DESCRIPTION
This makes it possible to compile templates inline, like:

```
var domthingify = require('domthingify');

AmpersandView.extend({
    title: 'My Title',
    template: domthingify(`
        <div class="content">
            {{ title }}
        </div>
   `)
});
```

It works by replacing calls to `domthingify` with the compiled template (using [static-module](https://github.com/substack/static-module)).

I would like to add some documentation, but the README on GitHub seems to be a bit behind the one on npm?
