### PR TITLE
Added repository entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "devDependencies": {
     "beefy": "^2.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/latentflip/domthingify"
+  },
   "license": "MIT",
   "main": "domthingify.js",
   "peerDependencies": {


### PR DESCRIPTION
This prevents the `npm WARN` messages from appearing during a `npm install` (as of npm v1.2.20), e.g. `npm WARN package.json ampersand-domthing-mixin@0.1.0 No repository field.`
